### PR TITLE
docs(deploy): link to repo for app deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sample Pollination Apps
 A collection of sample apps for Pollination.
 
-Pollination apps are built using [Streamlit app framework](https://github.com/streamlit/). 
+Pollination apps are built using [Streamlit app framework](https://github.com/streamlit/).
 
 If you are new Streamlit see their [get started documentation](https://docs.streamlit.io/library/get-started).
 
@@ -48,6 +48,10 @@ pip install -r requirements.txt
 streamlit run app.py
 
 ```
+
+# Deploying New Apps
+
+To deploy new apps from this repository to Pollination's backend follow the instruction in [`pollination/sample-apps-devops`](https://github.com/pollination/sample-apps-devops).
 
 # License
 See each app's subfolder for app's license


### PR DESCRIPTION
FYI @mostaphaRoudsari, @devngc and @AntonelloDN as you will be managing deployments for new streamlit apps I have created a separate repository where you can create the automated build pipelines for each app --> [`pollination/sample-apps-devops`](https://github.com/pollination/sample-apps-devops)

I have set this up as per Mostapha's request [here](https://3.basecamp.com/4298486/buckets/24505182/messages/4456777169)