### PR TITLE
refactor(helper.py): re-enable caching on get image

### DIFF
--- a/epw-viz/helper.py
+++ b/epw-viz/helper.py
@@ -111,6 +111,7 @@ def get_fields() -> dict:
     return {EPWFields._fields[i]['name'].name: i for i in range(6, 34)}
 
 
+@st.cache()
 def get_image(latitude: float, longitude: float) -> None:
     # find city name and create a keyword for search
     geolocator = Nominatim(user_agent="geoapiExercises")


### PR DESCRIPTION
@mostaphaRoudsari   I had disabled caching the image for a scenario where after loading an EPW file the user removes the file using the button
![button](https://user-images.githubusercontent.com/20086924/151656540-50f881a4-c6d1-4cf0-915e-c910b599f924.PNG)
In this case, the sample Boston weather data is loaded again but the image doesn't get updated sometimes. After thinking more about it I feel that it's safe to assume that the chances of a user deleting the uploaded EPW file are less. They will most likely move on if they are done analyzing the EPW that they uploaded. Considering that I re-enable caching the image in this PR.
